### PR TITLE
Modified Arm template to create storage account

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -43,9 +43,6 @@
         },
         "webJobStorageAccountName" : {
             "type": "string"
-        },
-        "webJobsStorageConnectionString" :{
-            "type" : "string"
         }
     },
     "variables": {},
@@ -205,12 +202,12 @@
                         "value": [
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "connectionString": "[parameters('webJobsStorageConnectionString')]",
+                                "connectionString": " [reference('StorageAccount').outputs.storageConnectionString.value]",
                                 "type": "Custom"
                               },
                               {
                                 "name": "AzureWebJobsStorage",
-                                "connectionString": "[parameters('webJobsStorageConnectionString')]",
+                                "connectionString": " [reference('StorageAccount').outputs.storageConnectionString.value]",
                                 "type": "Custom"
                               }
                         ]
@@ -218,7 +215,8 @@
                 }
             },
             "dependsOn": [
-                "worker-app-service-plan-deployment"
+                "worker-app-service-plan-deployment",
+                "StorageAccount"
             ]
         },
         {

--- a/azure/template.json
+++ b/azure/template.json
@@ -40,10 +40,33 @@
         },
         "cosmosDbName": {
             "type": "string" 
+        },
+        "webJobStorageAccountName" : {
+            "type": "string"
+        },
+        "webJobsStorageConnectionString" :{
+            "type" : "string"
         }
     },
     "variables": {},
     "resources": [
+        {
+            "apiVersion": "2017-05-10",
+            "name": "StorageAccount",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/storage-account-arm.json",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "storageAccountName": {
+                        "value": "[parameters('webJobStorageAccountName')]"
+                    }
+                }
+            }
+        },
         {
             "apiVersion": "2017-05-10",
             "name": "worker-app-service-plan-deployment",
@@ -176,6 +199,20 @@
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                                 "value": "[reference('worker-app-insights-deployment').outputs.InstrumentationKey.value]"
                             }
+                        ]
+                    },
+                    "appServiceConnectionStrings": {
+                        "value": [
+                            {
+                                "name": "AzureWebJobsDashboard",
+                                "connectionString": "[parameters('webJobsStorageConnectionString')]",
+                                "type": "Custom"
+                              },
+                              {
+                                "name": "AzureWebJobsStorage",
+                                "connectionString": "[parameters('webJobsStorageConnectionString')]",
+                                "type": "Custom"
+                              }
                         ]
                     }
                 }


### PR DESCRIPTION
Currently Webjobs are getting the following.

The configuration is not properly set for the Microsoft Azure WebJobs Dashboard. 
In your Microsoft Azure Website configuration you must set a connection string named AzureWebJobsDashboard by using the following format DefaultEndpointsProtocol=https;AccountName=NAME;AccountKey=KEY pointing to the Microsoft Azure Storage account where the Microsoft Azure WebJobs Runtime logs are stored. 

Please visit the article about configuring connection strings for more information on how you can configure connection strings in your Microsoft Azure Website.

This is to add the Storage account to allow the creation of the Configion string.