### PR TITLE
FAI-304 - Add AccountHashedId to be returned in response

### DIFF
--- a/src/SFA.DAS.ProviderRelationships.Api.UnitTests/Controllers/AccountProviderLegalEntities/GetTests.cs
+++ b/src/SFA.DAS.ProviderRelationships.Api.UnitTests/Controllers/AccountProviderLegalEntities/GetTests.cs
@@ -134,7 +134,8 @@ namespace SFA.DAS.ProviderRelationships.Api.UnitTests.Controllers.AccountProvide
 
             Result = new GetAccountProviderLegalEntitiesWithPermissionQueryResult(new[] {
                 new AccountProviderLegalEntityDto {
-                    AccountId = 41L, 
+                    AccountId = 41L,
+                    AccountHashedId = "TRE567",
                     AccountLegalEntityId = 4131L, 
                     AccountLegalEntityName = "AccountLegalEntityName",
                     AccountLegalEntityPublicHashedId = "ALEPHI", 

--- a/src/SFA.DAS.ProviderRelationships.Types/Dtos/AccountProviderLegalEntityDto.cs
+++ b/src/SFA.DAS.ProviderRelationships.Types/Dtos/AccountProviderLegalEntityDto.cs
@@ -3,6 +3,7 @@ namespace SFA.DAS.ProviderRelationships.Types.Dtos
     public class AccountProviderLegalEntityDto
     {
         public long AccountId { get; set; }
+        public string AccountHashedId { get; set; }
         public string AccountPublicHashedId { get; set; }
         public string AccountName { get; set; }
         public long AccountLegalEntityId { get; set; }

--- a/src/SFA.DAS.ProviderRelationships.UnitTests/Application/Queries/GetAccountProviderLegalEntitiesWithPermissionQueryHandlerTests.cs
+++ b/src/SFA.DAS.ProviderRelationships.UnitTests/Application/Queries/GetAccountProviderLegalEntitiesWithPermissionQueryHandlerTests.cs
@@ -34,6 +34,7 @@ namespace SFA.DAS.ProviderRelationships.UnitTests.Application.Queries
                     new AccountProviderLegalEntityDto
                     {
                         AccountId = f.Account.Id,
+                        AccountHashedId = f.Account.HashedId,
                         AccountPublicHashedId = f.Account.PublicHashedId,
                         AccountName = f.Account.Name,
                         AccountProviderId = f.AccountProvider.Id,
@@ -78,7 +79,7 @@ namespace SFA.DAS.ProviderRelationships.UnitTests.Application.Queries
 
         public GetAccountProviderLegalEntitiesWithPermissionQueryHandlerTestsFixture()
         {
-            Query = new GetAccountProviderLegalEntitiesWithPermissionQuery(88888888, null, null, new List<Operation>{Operation.CreateCohort});
+            Query = new GetAccountProviderLegalEntitiesWithPermissionQuery(88888888, null, null, new List<Operation>{Operation.Recruitment, Operation.RecruitmentRequiresReview});
 
             Db = new ProviderRelationshipsDbContext(new DbContextOptionsBuilder<ProviderRelationshipsDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).ConfigureWarnings(warnings => warnings.Throw(RelationalEventId.QueryClientEvaluationWarning)).Options);
             ConfigurationProvider = new MapperConfiguration(c => c.AddProfile<AccountProviderLegalEntityMappings>());

--- a/src/SFA.DAS.ProviderRelationships/Mappings/AccountProviderLegalEntityMappings.cs
+++ b/src/SFA.DAS.ProviderRelationships/Mappings/AccountProviderLegalEntityMappings.cs
@@ -14,6 +14,7 @@ namespace SFA.DAS.ProviderRelationships.Mappings
             CreateMap<AccountProviderLegalEntity, Types.Dtos.AccountProviderLegalEntityDto>()
                 .ForMember(d => d.AccountId, o => o.MapFrom(s => s.AccountProvider.Account.Id))
                 .ForMember(d => d.AccountPublicHashedId, o => o.MapFrom(s => s.AccountProvider.Account.PublicHashedId))
+                .ForMember(d => d.AccountHashedId, o => o.MapFrom(s => s.AccountProvider.Account.HashedId))
                 .ForMember(d => d.AccountName, o => o.MapFrom(s => s.AccountProvider.Account.Name));
 
             CreateMap<AccountProviderLegalEntity, Application.Queries.GetAccountProviderLegalEntity.Dtos.AccountProviderLegalEntityDto>()


### PR DESCRIPTION
The account hashed id is now returned as part of the get permissions API call.