### PR TITLE
Split query for simplification and generated SQL optimisation.

### DIFF
--- a/src/SFA.DAS.ProviderRelationships.Api/SFA.DAS.ProviderRelationships.Api.csproj
+++ b/src/SFA.DAS.ProviderRelationships.Api/SFA.DAS.ProviderRelationships.Api.csproj
@@ -54,6 +54,12 @@
     <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.6" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console">
+      <Version>2.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug">
+      <Version>2.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="6.10.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.10.1" />
     <PackageReference Include="Microsoft.Owin" Version="4.1.1" />

--- a/src/SFA.DAS.ProviderRelationships.Api/Web.config
+++ b/src/SFA.DAS.ProviderRelationships.Api/Web.config
@@ -5,6 +5,7 @@
     </configSections>
     <appSettings>
         <add key="APPINSIGHTS_INSTRUMENTATIONKEY" value=""/>
+        <add key="EnvironmentName" value="LOCAL" />
     </appSettings>
     <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd">
         <variable name="appName" value="das-providerrelationships-api"/>

--- a/src/SFA.DAS.ProviderRelationships/Application/Queries/GetAccountProviderLegalEntitiesWithPermission/GetAccountProviderLegalEntitiesWithPermissionQueryHandler.cs
+++ b/src/SFA.DAS.ProviderRelationships/Application/Queries/GetAccountProviderLegalEntitiesWithPermission/GetAccountProviderLegalEntitiesWithPermissionQueryHandler.cs
@@ -24,12 +24,32 @@ namespace SFA.DAS.ProviderRelationships.Application.Queries.GetAccountProviderLe
         
         public async Task<GetAccountProviderLegalEntitiesWithPermissionQueryResult> Handle(GetAccountProviderLegalEntitiesWithPermissionQuery request, CancellationToken cancellationToken)
         {
-            var relationships = await _db.Value.AccountProviderLegalEntities
-                .Where(aple => 
-                    aple.AccountProvider.ProviderUkprn == (request.Ukprn ?? aple.AccountProvider.ProviderUkprn) && 
-                    aple.AccountProvider.Account.HashedId == (request.AccountHashedId ?? aple.AccountProvider.Account.HashedId) &&
-                    aple.AccountLegalEntity.PublicHashedId == (request.AccountLegalEntityPublicHashedId ?? aple.AccountLegalEntity.PublicHashedId) &&
-                    aple.Permissions.Any(p => request.Operations.Contains(p.Operation)))
+            var relationshipsQuery = _db.Value.AccountProviderLegalEntities
+                .IgnoreQueryFilters() //removing the queryfilter on AccountLegalEntity here prevents the query being generated with inneficient subqueries
+                .Where(aple =>
+                    aple.Permissions.Any(p => request.Operations.Contains(p.Operation)));
+
+            if (request.Ukprn.HasValue)
+            {
+                relationshipsQuery = relationshipsQuery.Where(aple =>
+                    aple.AccountProvider.ProviderUkprn == request.Ukprn);
+            }
+
+            if (!string.IsNullOrEmpty(request.AccountHashedId))
+            {
+                relationshipsQuery = relationshipsQuery.Where(aple =>
+                   aple.AccountProvider.Account.HashedId == request.AccountHashedId);
+            }
+
+            if(!string.IsNullOrEmpty(request.AccountLegalEntityPublicHashedId))
+            {
+                relationshipsQuery = relationshipsQuery.Where(aple =>
+                   aple.AccountLegalEntity.PublicHashedId == request.AccountLegalEntityPublicHashedId);
+            }
+
+
+            var relationships = await relationshipsQuery
+                .Where(aple => aple.AccountLegalEntity.Deleted != null)
                 .ProjectTo<AccountProviderLegalEntityDto>(_configurationProvider)
                 .ToListAsync(cancellationToken);
 

--- a/src/SFA.DAS.ProviderRelationships/SFA.DAS.ProviderRelationships.csproj
+++ b/src/SFA.DAS.ProviderRelationships/SFA.DAS.ProviderRelationships.csproj
@@ -13,6 +13,8 @@
         <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
         <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
         <PackageReference Include="NLog.Extensions.Logging" Version="1.3.0" />
         <PackageReference Include="SFA.DAS.Authorization" Version="1.1.1" />


### PR DESCRIPTION
Ignoring the query filter on AccountLegalEntity prevents the query being generated with inneficient subqueries